### PR TITLE
Remove dependency on `ctx->req` in `purge()`

### DIFF
--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -482,12 +482,9 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 	unsigned char digest[DIGEST_LEN];
 	struct xkey_hashhead *hashhead;
 	struct xkey_oc *oc;
-	double now;
 	int i;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	if (ctx->req == NULL)
-		return (0);
 
 	if (!key || !*key)
 		return (0);
@@ -503,16 +500,15 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 		return (0);
 	}
 	i = 0;
-	now = ctx->req->t_prev;
 	VTAILQ_FOREACH(oc, &hashhead->ocs, list_hashhead) {
 		CHECK_OBJ_NOTNULL(oc->objcore, OBJCORE_MAGIC);
 		if (oc->objcore->flags & OC_F_BUSY)
 			continue;
 		if (do_soft &&
-		    oc->objcore->exp.ttl <= (now - oc->objcore->exp.t_origin))
+		    oc->objcore->exp.ttl <= (ctx->now - oc->objcore->exp.t_origin))
 			continue;
 		if (do_soft)
-			EXP_Rearm(oc->objcore, now, 0,
+			EXP_Rearm(oc->objcore, ctx->now, 0,
 			    oc->objcore->exp.grace, oc->objcore->exp.keep);
 		else
 			EXP_Rearm(oc->objcore, oc->objcore->exp.t_origin, 0,


### PR DESCRIPTION
I want to soft-purge cached objects when a response returned by the back-end server contains `xkey-purge` header. But putting this code in VCL does nothing:

``` VCL
sub vcl_backend_response {
    if (beresp.http.xkey-purge) {
        std.log("Soft-purged " + xkey.softpurge(beresp.http.xkey-purge) + " objects tagged with [" + beresp.http.xkey-purge + "]");
        unset beresp.http.xkey-purge;
    }
}
```

... since the `purge()` function requires non-NULL `ctx->req` to get timestamp. Is it really necessary, or we can safely replace it with `ctx->now` as suggested by this patch?
